### PR TITLE
Removed extra let

### DIFF
--- a/applet.js
+++ b/applet.js
@@ -1118,7 +1118,7 @@ SlingshotView.prototype = {
         });
         this.viewSelector.append(image, _('View as Grid'));
 
-        let image = new St.Icon({
+        image = new St.Icon({
             icon_size: 16,
             gicon: new Gio.ThemedIcon({ name: 'view-list-symbolic' })
         });


### PR DESCRIPTION
The redeclaration of image was causing the applet to crash on startup.

```
error t=2017-06-29T17:06:22Z redeclaration of let image
error t=2017-06-29T17:06:22Z [Applet "slingshot@jfarthing84"]: Error importing applet.js from slingshot@jfarthing84
error t=2017-06-29T17:06:22Z Could not load applet slingshot@jfarthing84
```